### PR TITLE
Use Oncelock instead of lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,15 +15,8 @@ dependencies = [
 name = "detect-indent"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "regex",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,3 @@ repository = "https://github.com/stefanpenner/detect-indent-rs"
 
 [dependencies]
 regex = "1"
-lazy_static = "1"


### PR DESCRIPTION
Use Oncelock introduced in rust stdlib to reduce dependencies

This does change MSRV from 1.56.1 to 1.70.0 (checked with https://github.com/foresterre/cargo-msrv)

If this is not acceptable, feel free to close this PR